### PR TITLE
Fix issue #53: AttributeError: 'Slice' object has no attribute 'value'

### DIFF
--- a/pythonjs/pythonjs.py
+++ b/pythonjs/pythonjs.py
@@ -135,7 +135,7 @@ class JSGenerator(NodeVisitor):
 			name = self.visit(node.value)
 			return '%s["$wrapped"]' %name
 		else:
-			return '%s[%s]' % (self.visit(node.value), self.visit(node.slice.value))
+			return '%s[%s]' % (self.visit(node.value), self.visit(node.slice))
 
 	def visit_arguments(self, node):
 		out = []


### PR DESCRIPTION
I am not sure the fix is correct, because I still fail to completely translate my lib, but I am using Python 2.7 and I am pretty sure that Slice node doesn't have value attribute there even though it is not documented - http://bugs.python.org/issue19557
